### PR TITLE
refactor: 네트워크 레이어 리팩터링

### DIFF
--- a/src/Projects/BKCore/Sources/DiContainer/Autowired.swift
+++ b/src/Projects/BKCore/Sources/DiContainer/Autowired.swift
@@ -7,13 +7,17 @@
 ///
 /// ### Example
 /// ```swift
-/// /// In Coordinator
-/// func createMyViewController() -> MYViewController {
-///     @Autowired var usecase: MyUseCase
-///     let viewmodel = MyViewModel(usecase: usecase)
-///     return MyViewController(viewmodel: viewmodel)
-/// }
+/// /// In ViewModel
+/// @Autowired(name: "apple") private var appleLoginUseCase: SocialLoginUseCase
+/// @Autowired(name: "kakao") private var kakaoLoginUseCase: SocialLoginUseCase
+/// @Autowired private var socialTokenAuthUseCase: SocialTokenAuthUseCase
 /// ```
+///
+/// ### 활용 방법
+/// ViewModel을 제외한 모든 계층에서는 `Assembly`에서 `@Autowired`로 주입합니다.
+/// Data, Domain 등의 계층에서는 테스트가 필수불가결적이므로 생성자 주입을 통한 DI를 활용해주세요.
+/// 단, ViewModel의 경우에는 편리하게 `@Autowired` 주입을 추천드립니다.
+/// `Coordinator`에서의 불필요한 라인을 줄일 수 있습니다.
 @propertyWrapper
 public struct Autowired<T> {
     private var service: T

--- a/src/Projects/BKData/Sources/Error/NetworkError.swift
+++ b/src/Projects/BKData/Sources/Error/NetworkError.swift
@@ -6,4 +6,6 @@ public enum NetworkError: Error {
     case unauthorized
     case internalServerError
     case timeout
+    case retryTrigger
+    case unknown
 }

--- a/src/Projects/BKData/Sources/Interface/Network/NetworkProvider.swift
+++ b/src/Projects/BKData/Sources/Interface/Network/NetworkProvider.swift
@@ -7,5 +7,5 @@ public protocol NetworkProvider {
     func request<T: Decodable>(
         target: RequestTarget,
         type: T.Type
-    ) -> AnyPublisher<T, Error>
+    ) -> AnyPublisher<T, NetworkError>
 }

--- a/src/Projects/BKData/Sources/Interface/Network/URLBuilding.swift
+++ b/src/Projects/BKData/Sources/Interface/Network/URLBuilding.swift
@@ -1,7 +1,8 @@
 // Copyright © 2025 Booket. All rights reserved
 
+import Combine
 import Foundation
 
 public protocol URLBuilding {
-    func makeURL(target: RequestTarget) throws -> URL?
+    func makeURL(target: RequestTarget) -> AnyPublisher<URL, NetworkError>
 }

--- a/src/Projects/BKNetwork/Sources/Error/RetryTrigger.swift
+++ b/src/Projects/BKNetwork/Sources/Error/RetryTrigger.swift
@@ -1,5 +1,0 @@
-// Copyright © 2025 Booket. All rights reserved
-
-import Foundation
-
-struct RetryTrigger: Error {}

--- a/src/Projects/BKNetwork/Sources/Extension/HTTPURLResponse+.swift
+++ b/src/Projects/BKNetwork/Sources/Extension/HTTPURLResponse+.swift
@@ -1,6 +1,7 @@
 // Copyright © 2025 Booket. All rights reserved
 
 import BKCore
+import BKData
 import Foundation
 import OSLog
 

--- a/src/Projects/BKNetwork/Sources/Extension/Publisher+.swift
+++ b/src/Projects/BKNetwork/Sources/Extension/Publisher+.swift
@@ -1,8 +1,9 @@
 // Copyright © 2025 Booket. All rights reserved
 
+import BKData
 import Combine
 
-extension Publisher {
+extension Publisher where Failure == NetworkError {
     func retryIf(
         _ shouldRetry: @escaping (Failure) -> Bool,
         maxRetries: Int

--- a/src/Projects/BKNetwork/Sources/Extension/RequestTarget+.swift
+++ b/src/Projects/BKNetwork/Sources/Extension/RequestTarget+.swift
@@ -1,6 +1,7 @@
 // Copyright © 2025 Booket. All rights reserved
 
 import BKData
+import Combine
 import Foundation
 
 extension RequestTarget {
@@ -8,15 +9,18 @@ extension RequestTarget {
         return [:]
     }
     
-    func makeURLRequest(accessToken: String = "") throws -> URLRequest {
-        var request: URLRequest = try URLRequest(baseURL + path, query: query)
-        
-        request.makeURLHeaders(headers)
-        request.addAuthorization(accessToken)
-        request.httpMethod = method.rawValue
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        
-        if let body { request.setBody(body) }
-        return request
+    func makeURLRequest() -> AnyPublisher<URLRequest, NetworkError> {
+        Just(())
+            .setFailureType(to: NetworkError.self)
+            .tryMap { _ in
+                var request = try URLRequest(baseURL + path, query: query)
+                request.makeURLHeaders(headers)
+                request.httpMethod = method.rawValue
+                request.cachePolicy = .reloadIgnoringLocalCacheData
+                if let body { request.setBody(body) }
+                return request
+            }
+            .mapError { error in error as? NetworkError ?? NetworkError.invalidURL }
+            .eraseToAnyPublisher()
     }
 }

--- a/src/Projects/BKNetwork/Sources/Extension/URLRequest+.swift
+++ b/src/Projects/BKNetwork/Sources/Extension/URLRequest+.swift
@@ -1,5 +1,6 @@
 // Copyright © 2025 Booket. All rights reserved
 
+import BKData
 import Foundation
 
 extension URLRequest {

--- a/src/Projects/BKNetwork/Sources/Helper/AuthInterceptor.swift
+++ b/src/Projects/BKNetwork/Sources/Helper/AuthInterceptor.swift
@@ -26,7 +26,7 @@ public struct AuthInterceptor {
             .orThrow(NetworkError.invalidResponse)
         if httpResponse.statusCode == 401 {
             tokenProvider.refreshIfNeeded()
-            throw RetryTrigger()
+            throw NetworkError.retryTrigger
         }
     }
 }

--- a/src/Projects/BKNetwork/Sources/Helper/URLBuilder.swift
+++ b/src/Projects/BKNetwork/Sources/Helper/URLBuilder.swift
@@ -1,10 +1,20 @@
 // Copyright © 2025 Booket. All rights reserved
 
 import BKData
+import Combine
 import Foundation
 
 public struct URLBuilder: URLBuilding {
-    public func makeURL(target: RequestTarget) throws -> URL? {
-        return try target.makeURLRequest().url
+    public func makeURL(target: RequestTarget) -> AnyPublisher<URL, NetworkError> {
+        return target
+            .makeURLRequest()
+            .tryMap { request in
+                guard let url = request.url else {
+                    throw NetworkError.invalidURL
+                }
+                return url
+            }
+            .mapError { $0 as? NetworkError ?? .invalidURL }
+            .eraseToAnyPublisher()
     }
 }

--- a/src/Projects/BKNetwork/Sources/Provider/DefaultNetworkProvider.swift
+++ b/src/Projects/BKNetwork/Sources/Provider/DefaultNetworkProvider.swift
@@ -17,20 +17,19 @@ public struct DefaultNetworkProvider: NetworkProvider {
     public func request<T: Decodable>(
         target: RequestTarget,
         type: T.Type
-    ) -> AnyPublisher<T, Error> {
-        do {
-            let request = try target.makeURLRequest()
-            return requestor.data(for: request)
-                .tryMap { data, response in
-                    try response.asHTTP
-                        .orThrow(NetworkError.invalidResponse)
-                        .validate(data)
-                    return try data.decode(to: type)
-                }
-                .eraseToAnyPublisher()
-        } catch {
-            return Fail(error: error)
-                .eraseToAnyPublisher()
-        }
+    ) -> AnyPublisher<T, NetworkError> {
+        return target.makeURLRequest()
+            .flatMap { request in
+                requestor.data(for: request)
+                    .tryMap { data, response in
+                        try response.asHTTP
+                            .orThrow(NetworkError.invalidResponse)
+                            .validate(data)
+                        return try data.decode(to: type)
+                    }
+                    .debugError("Decoding Failed", logger: AppLogger.network)
+                    .mapError { $0 as? NetworkError ?? .invalidResponse }
+            }
+            .eraseToAnyPublisher()
     }
 }

--- a/src/Projects/BKNetwork/Sources/Provider/OAuthNetworkProvider.swift
+++ b/src/Projects/BKNetwork/Sources/Provider/OAuthNetworkProvider.swift
@@ -1,5 +1,6 @@
 // Copyright © 2025 Booket. All rights reserved
 
+import BKCore
 import BKData
 import Combine
 import Foundation
@@ -17,22 +18,21 @@ public struct OAuthNetworkProvider: NetworkProvider {
     public func request<T: Decodable>(
         target: RequestTarget,
         type: T.Type
-    ) -> AnyPublisher<T, Error> {
-        do {
-            let adaptedRequest = try interceptor.adapt(target.makeURLRequest())
-            return requestor.data(for: adaptedRequest)
-                .tryMap { data, response in
-                    try response.asHTTP
-                        .orThrow(NetworkError.invalidResponse)
-                        .validate(data)
-                    try interceptor.retryIfNeeded(response, data)
-                    return try data.decode(to: type)
-                }
-                .retryIf({ $0 is RetryTrigger }, maxRetries: 1)
-                .eraseToAnyPublisher()
-        } catch {
-            return Fail(error: error)
-                .eraseToAnyPublisher()
-        }
+    ) -> AnyPublisher<T, NetworkError> {
+        return target.makeURLRequest()
+            .flatMap { request in
+                let adaptedRequest = interceptor.adapt(request)
+                return requestor.data(for: adaptedRequest)
+                    .tryMap { data, response in
+                        try response.asHTTP
+                            .orThrow(NetworkError.invalidResponse)
+                            .validate(data)
+                        try interceptor.retryIfNeeded(response, data)
+                        return try data.decode(to: type)
+                    }
+                    .mapError { $0 as? NetworkError ?? .invalidResponse }
+            }
+            .retryIf({ $0 == NetworkError.retryTrigger }, maxRetries: 1)
+            .eraseToAnyPublisher()
     }
 }

--- a/src/Projects/BKNetwork/Sources/Provider/OAuthNetworkProvider.swift
+++ b/src/Projects/BKNetwork/Sources/Provider/OAuthNetworkProvider.swift
@@ -24,10 +24,10 @@ public struct OAuthNetworkProvider: NetworkProvider {
                 let adaptedRequest = interceptor.adapt(request)
                 return requestor.data(for: adaptedRequest)
                     .tryMap { data, response in
+                        try interceptor.retryIfNeeded(response, data)
                         try response.asHTTP
                             .orThrow(NetworkError.invalidResponse)
                             .validate(data)
-                        try interceptor.retryIfNeeded(response, data)
                         return try data.decode(to: type)
                     }
                     .mapError { $0 as? NetworkError ?? .invalidResponse }


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #57 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [ ] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [x] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [x] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- NetworkError가 상위 모듈이 아닌 Network Layer에 잘못 위치하던 부분 수정
- 일부 throwable한 메소드를 AnyPublisher로 변경
- `@Autowired`의 가이드 수정


## 🧪 테스트 내역
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- `@Autowired`는 사실 생각한게 있어서 그 부분 수정하려고 했는데 이미 잘 되어있었어서... 문서만 수정했습니다.
- throwable한 메소드들을 과연 `AnyPublisher`로 전부 묶는게 맞는 건지 잘 모르겠습니다.
  - 일단 바꿀만한 것들만 조금 바꿨고 애매한 것들은 냅뒀는데요. 처음부터 Combine 설계를 했으면 모를까 어렵네요.
  - 나중에 각잡고 리팩터링 하겠습니다...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * `@Autowired` 프로퍼티 래퍼 사용 예시와 가이드가 개선되었습니다.

* **신규 기능**
  * 네트워크 오류 타입에 `retryTrigger`와 `unknown` 케이스가 추가되었습니다.

* **버그 수정**
  * 네트워크 요청 및 URL 생성 관련 오류 처리가 더욱 구체적인 `NetworkError` 타입으로 통일되었습니다.
  * 네트워크 요청 흐름이 비동기 스트림 기반으로 개선되어 오류 발생 시 일관된 처리가 가능합니다.

* **리팩터**
  * 네트워크 요청, URL 생성, 오류 처리 로직이 Combine 기반의 비동기 스트림으로 전환되었습니다.
  * 불필요한 사용자 정의 오류 타입(`RetryTrigger`)이 제거되었습니다.
  * 네트워크 요청 재시도 로직이 `NetworkError.retryTrigger` 조건에 맞게 개선되었습니다.

* **기타**
  * 일부 파일에 모듈 임포트가 추가되어 의존성이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->