### PR TITLE
fix: 설정 화면 터치 피드백 제거

### DIFF
--- a/src/Projects/BKPresentation/Sources/MainFlow/Setting/View/SettingView.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Setting/View/SettingView.swift
@@ -121,6 +121,13 @@ extension SettingView: UICollectionViewDelegate {
             return true
         }
     }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        shouldHighlightItemAt indexPath: IndexPath
+    ) -> Bool {
+        return false
+    }
 }
 
 extension SettingView: UICollectionViewDataSource {


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #86 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [ ] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- CollectionView에서 하이라이트 비활성화


## 🧪 테스트 내역
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 설정 화면의 컬렉션 뷰 항목 터치 시 하이라이트 효과가 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->