### PR TITLE
feat: 내 서재 검색 이후 액션 추가

### DIFF
--- a/src/Projects/BKDesign/Sources/Components/Summary/BKBookSummaryView.swift
+++ b/src/Projects/BKDesign/Sources/Components/Summary/BKBookSummaryView.swift
@@ -192,12 +192,12 @@ public class BKBookSummaryView: UIView {
             }
         }
 
-        authorLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        authorLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        authorLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        authorLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         separatorLabel.setContentHuggingPriority(.required, for: .horizontal)
         separatorLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         publisherLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        publisherLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        publisherLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
 
     private func setupLayouts() {
@@ -245,8 +245,9 @@ public class BKBookSummaryView: UIView {
         recordCount: Int? = nil,
         image: URL? = nil
     ) {
+        let wrappedAuthor = author.isEmpty ? "저자 정보 없음" : author
         titleLabel.setText(text: title)
-        authorLabel.setText(text: author)
+        authorLabel.setText(text: wrappedAuthor)
         publisherLabel.setText(text: publisher)
         thumbnail.clipsToBounds = true
         thumbnail.layer.cornerRadius = LayoutConstants.imageRadius

--- a/src/Projects/BKDomain/Sources/Entity/BookInfo.swift
+++ b/src/Projects/BKDomain/Sources/Entity/BookInfo.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public struct BookInfo: Equatable {
+public struct BookInfo: Equatable, Hashable {
     public let bookId: String
     public let isbn: String
     public let title: String

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/Coordinator/SearchCoordinator.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/Coordinator/SearchCoordinator.swift
@@ -46,4 +46,15 @@ extension SearchCoordinator {
         addChildCoordinator(noteCoordinator)
         noteCoordinator.start()
     }
+    
+    func didTapBookDetail(isbn: String, userBookId: String) {
+        let bookDetailCoordinator = BookDetailCoordinator(
+            parentCoordinator: self,
+            navigationController: navigationController,
+            isbn: isbn,
+            userBookId: userBookId
+        )
+        addChildCoordinator(bookDetailCoordinator)
+        bookDetailCoordinator.start()
+    }
 }

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchResultCell.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchResultCell.swift
@@ -45,10 +45,15 @@ final class SearchResultCell: UICollectionViewCell {
         description: BookDescription,
         image: URL?,
         canSelect: Bool = true,
-        recordCount: Int? = nil
+        recordCount: Int? = nil,
+        isLibraryBook: Bool = false
     ) {
         let style: BKBookSummaryViewStyle = {
-            if recordCount != nil {
+            if isLibraryBook && recordCount != nil {
+                return .record
+            } else if isLibraryBook {
+                return .alreadyEnroll
+            } else if recordCount != nil {
                 return .record
             } else if canSelect {
                 return .regular

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchView.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchView.swift
@@ -100,7 +100,8 @@ final class SearchView: BaseView {
             }
             
         case .result(let state):
-            if state.books.isEmpty {
+            let isEmpty = state.books.isEmpty && state.bookInfos.isEmpty
+            if isEmpty {
                 header.layoutIfNeeded()
                 let headerHeight = header.bounds.height
                 let offset = -(headerHeight / 2.0)
@@ -109,7 +110,9 @@ final class SearchView: BaseView {
             } else {
                 collectionView.backgroundView = nil
                 snapshot.appendSections([.result])
+                // Book과 BookInfo 모두 처리
                 snapshot.appendItems(state.books.map { .result($0) }, toSection: .result)
+                snapshot.appendItems(state.bookInfos.map { .libraryResult($0) }, toSection: .result)
                 searchBar.setClearButtonMode(.always)
             }
             header.setTitle(.result(count: count))
@@ -140,6 +143,8 @@ private extension SearchView {
                 return self.makeRecentKeywordCell(in: collectionView, at: indexPath, keyword: keyword)
             case .result(let result):
                 return self.makeSearchResultCell(in: collectionView, at: indexPath, book: result)
+            case .libraryResult(let bookInfo):
+                return self.makeLibraryResultCell(in: collectionView, at: indexPath, bookInfo: bookInfo)
             }
         }
         
@@ -207,6 +212,34 @@ private extension SearchView {
                 recordCount: book.recordCount
             )
         }
+
+        return cell
+    }
+    
+    func makeLibraryResultCell(
+        in collectionView: UICollectionView,
+        at indexPath: IndexPath,
+        bookInfo: BookInfo
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: SearchResultCell.identifier,
+            for: indexPath
+        ) as? SearchResultCell else {
+            return UICollectionViewCell()
+        }
+        
+        // BookInfo는 내 서재 도서 - 터치 가능하고 recordCount가 있으면 .record 스타일
+        cell.configure(
+            title: bookInfo.title,
+            description: .init(
+                author: bookInfo.author,
+                publisher: bookInfo.publisher
+            ),
+            image: bookInfo.imageUrl,
+            canSelect: true,
+            recordCount: bookInfo.recordCount,
+            isLibraryBook: true
+        )
 
         return cell
     }
@@ -286,8 +319,20 @@ extension SearchView: UICollectionViewDelegate {
         didSelectItemAt indexPath: IndexPath
     ) {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
-        if case let .result(book) = item {
-            eventPublisher.send(.upsertBook(book.isbn))
+        
+        switch item {
+        case .result(let book):
+            switch book.userBookStatus {
+            case .beforeRegistration, nil:
+                eventPublisher.send(.upsertBook(book.isbn))
+            default:
+                break
+            }
+            
+        case .libraryResult(let bookInfo):
+            eventPublisher.send(.goToBookDetail(isbn: bookInfo.isbn, userBookId: bookInfo.bookId))
+            
+        case .query: break
         }
     }
 }

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchViewController.swift
@@ -41,7 +41,7 @@ final class SearchViewController: BaseViewController<SearchView> {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = true
         
-        viewModel.send(.onAppear)
+        viewModel.send(.onAppearWithoutReset)
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchViewController.swift
@@ -10,6 +10,7 @@ enum SearchViewEvent: Equatable {
     case loadNextPage
     case deleteRecentQuery(String)
     case upsertBook(String)
+    case goToBookDetail(isbn: String, userBookId: String)
 }
 
 final class SearchViewController: BaseViewController<SearchView> {
@@ -86,6 +87,17 @@ final class SearchViewController: BaseViewController<SearchView> {
             .throttle(for: .milliseconds(800), scheduler: RunLoop.main, latest: false)
             .sink { [weak self] query in
                 self?.presentBookRegistration(with: query)
+            }
+            .store(in: &cancellable)
+            
+        contentView.eventPublisher
+            .compactMap { event -> (String, String)? in
+                if case let .goToBookDetail(isbn, userBookId) = event { return (isbn, userBookId) }
+                return nil
+            }
+            .throttle(for: .milliseconds(800), scheduler: RunLoop.main, latest: false)
+            .sink { [weak self] (isbn, userBookId) in
+                self?.coordinator?.didTapBookDetail(isbn: isbn, userBookId: userBookId)
             }
             .store(in: &cancellable)
     }

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/ViewModel/SearchViewModel.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/ViewModel/SearchViewModel.swift
@@ -8,6 +8,7 @@ import Foundation
 enum SearchItem: Hashable {
     case query(String)
     case result(Book)
+    case libraryResult(BookInfo)
 }
 
 struct RecentState: Equatable {
@@ -17,7 +18,20 @@ struct RecentState: Equatable {
 
 struct ResultState: Equatable {
     let books: [Book]
+    let bookInfos: [BookInfo]
     let placeholder: String
+    
+    init(books: [Book], placeholder: String) {
+        self.books = books
+        self.bookInfos = []
+        self.placeholder = placeholder
+    }
+    
+    init(bookInfos: [BookInfo], placeholder: String) {
+        self.books = []
+        self.bookInfos = bookInfos
+        self.placeholder = placeholder
+    }
 }
 
 enum SearchViewType: String {
@@ -56,20 +70,6 @@ enum SearchViewType: String {
     }
 }
 
-struct MyLibrarySearchAdapter: SearchBookUseCase {
-    let wrapped: MyLibrarySearchBookUseCase
-    let map: (BookInfo) -> Book
-
-    func execute(
-        query: String?,
-        startIndex: Int?,
-        isGuestMode: Bool
-    ) -> AnyPublisher<(books: [Book], totalResults: Int), DomainError> {
-        wrapped.execute(query: query, startIndex: startIndex)
-            .map { (books: $0.books.map(map), totalResults: $0.totalResults) }
-            .eraseToAnyPublisher()
-    }
-}
 
 final class SearchViewModel: BaseViewModel {
     enum SearchState: Equatable {
@@ -103,6 +103,7 @@ final class SearchViewModel: BaseViewModel {
         case upsertBook(isbn: String, status: BookRegistrationStatus)
         case fetchRecentQueriesSuccessed([String])
         case fetchSearchResultSuccessed((books: [Book], totalResults: Int))
+        case fetchLibrarySearchResultSuccessed((bookInfos: [BookInfo], totalResults: Int))
         case fetchNextPageSuccessed([Book])
         case upsertBookSuccessed(isbn: String, bookId: String)
         case noteSuggestionShown
@@ -125,6 +126,7 @@ final class SearchViewModel: BaseViewModel {
     private let sideEffectSubject = PassthroughSubject<SideEffect, Never>()
     private let pageSize = 10
     private var allBooks: [Book] = []
+    private var allBookInfos: [BookInfo] = []
     private var currentQuery: String?
     private var currentPage = 1
     private let searchViewType: SearchViewType
@@ -148,17 +150,8 @@ final class SearchViewModel: BaseViewModel {
     @Autowired var defaultSearchUseCase: SearchBookUseCase
     @Autowired var myLibrarySearchUseCase: MyLibrarySearchBookUseCase
     
-    private lazy var searchBookUseCase: SearchBookUseCase = {
-        switch searchViewType {
-        case .defaultSearch:
-            return defaultSearchUseCase
-        case .myLibrarySearch:
-            return MyLibrarySearchAdapter(
-                wrapped: myLibrarySearchUseCase,
-                map: mapBookInfoToBook
-            )
-        }
-    }()
+    // SearchBookUseCase는 defaultSearch에서만 사용
+    // myLibrarySearch에서는 myLibrarySearchUseCase를 직접 사용
     
     @Autowired private var upsertUseCase: BookUpsertUseCase
     
@@ -213,6 +206,7 @@ final class SearchViewModel: BaseViewModel {
             
         case .fetchSearchResultSuccessed(let result):
             allBooks = result.books
+            allBookInfos = []
             newState.totalResults = result.totalResults
             newState.isLoading = false
             newState.searchState = .result(
@@ -222,6 +216,19 @@ final class SearchViewModel: BaseViewModel {
                 )
             )
             newState.hasMoreData = allBooks.count < result.totalResults
+            
+        case .fetchLibrarySearchResultSuccessed(let result):
+            allBookInfos = result.bookInfos
+            allBooks = []
+            newState.totalResults = result.totalResults
+            newState.isLoading = false
+            newState.searchState = .result(
+                ResultState(
+                    bookInfos: result.bookInfos,
+                    placeholder: searchViewType.resultPlaceholder
+                )
+            )
+            newState.hasMoreData = allBookInfos.count < result.totalResults
             
         case .loadNextPage:
             guard !state.isLoading, state.hasMoreData else { break }
@@ -318,39 +325,74 @@ final class SearchViewModel: BaseViewModel {
                 .eraseToAnyPublisher()
             
         case .searchResult(let query):
-            return Publishers.Zip(
-                searchBookUseCase.execute(
-                    query: query,
-                    startIndex: currentPage,
-                    isGuestMode: AccessModeCenter.shared.mode.value == .guest
-                ),
-                storeRecentSearchUseCase.execute(query: query)
-                    .setFailureType(to: DomainError.self)
-            )
-            .map { (result, _) in
-                Action.fetchSearchResultSuccessed(result)
+            if searchViewType == .myLibrarySearch {
+                return Publishers.Zip(
+                    myLibrarySearchUseCase.execute(
+                        query: query,
+                        startIndex: currentPage
+                    ),
+                    storeRecentSearchUseCase.execute(query: query)
+                        .setFailureType(to: DomainError.self)
+                )
+                .map { (result, _) in
+                    Action.fetchLibrarySearchResultSuccessed(result)
+                }
+                .catch { [weak self] in
+                    self?.lastEffect = .searchResult(query)
+                    return Just(Action.errorOccured($0))
+                }
+                .eraseToAnyPublisher()
+            } else {
+                return Publishers.Zip(
+                    defaultSearchUseCase.execute(
+                        query: query,
+                        startIndex: currentPage,
+                        isGuestMode: AccessModeCenter.shared.mode.value == .guest
+                    ),
+                    storeRecentSearchUseCase.execute(query: query)
+                        .setFailureType(to: DomainError.self)
+                )
+                .map { (result, _) in
+                    Action.fetchSearchResultSuccessed(result)
+                }
+                .catch { [weak self] in
+                    self?.lastEffect = .searchResult(query)
+                    return Just(Action.errorOccured($0))
+                }
+                .eraseToAnyPublisher()
             }
-            .catch { [weak self] in
-                self?.lastEffect = .searchResult(query)
-                return Just(Action.errorOccured($0))
-            }
-            .eraseToAnyPublisher()
             
         case .loadNextPage:
             guard let query = currentQuery else {
                 return Empty().eraseToAnyPublisher()
             }
-            return searchBookUseCase.execute(
-                query: query,
-                startIndex: currentPage,
-                isGuestMode: AccessModeCenter.shared.mode.value == .guest
-            )
-            .map { Action.fetchNextPageSuccessed($0.books) }
-            .catch { [weak self] in
-                self?.lastEffect = .loadNextPage
-                return Just(Action.errorOccured($0))
+            if searchViewType == .myLibrarySearch {
+                return myLibrarySearchUseCase.execute(
+                    query: query,
+                    startIndex: currentPage
+                )
+                .map { result in
+                    let books = result.books.map(self.mapBookInfoToBook)
+                    return Action.fetchNextPageSuccessed(books)
+                }
+                .catch { [weak self] in
+                    self?.lastEffect = .loadNextPage
+                    return Just(Action.errorOccured($0))
+                }
+                .eraseToAnyPublisher()
+            } else {
+                return defaultSearchUseCase.execute(
+                    query: query,
+                    startIndex: currentPage,
+                    isGuestMode: AccessModeCenter.shared.mode.value == .guest
+                )
+                .map { Action.fetchNextPageSuccessed($0.books) }
+                .catch { [weak self] in
+                    self?.lastEffect = .loadNextPage
+                    return Just(Action.errorOccured($0))
+                }
+                .eraseToAnyPublisher()
             }
-            .eraseToAnyPublisher()
             
         case .upsert(let isbn, let status):
             return upsertUseCase.execute(

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/ViewModel/SearchViewModel.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/ViewModel/SearchViewModel.swift
@@ -96,6 +96,7 @@ final class SearchViewModel: BaseViewModel {
     
     enum Action {
         case onAppear
+        case onAppearWithoutReset  // 검색 결과 유지한 채로 appear
         case search(String)
         case loadNextPage
         case loadNoteFlow
@@ -187,6 +188,13 @@ final class SearchViewModel: BaseViewModel {
         case .onAppear:
             newState.isLoading = true
             effects.append(.recentQueries)
+            
+        case .onAppearWithoutReset:
+            // 검색 결과가 있으면 유지, 없으면 최근 검색어 로드
+            if case .recent = state.searchState {
+                newState.isLoading = true
+                effects.append(.recentQueries)
+            }
             
         case .search(let query):
             currentQuery = query

--- a/src/Projects/BKPresentation/Sources/MainFlow/Setting/View/SettingViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Setting/View/SettingViewController.swift
@@ -101,7 +101,6 @@ final class SettingViewController: BaseViewController<SettingView> {
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
-                print(error)
                 self?.coordinator?.handleError(error)
                 self?.viewModel.send(.errorHandled)
             }


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #188 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [x] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 내 서재 검색 화면에서 셀을 탭하면 독서 기록 화면으로 이동하는 기능 추가
- 내 서재 검색 화면에서 셀이 터치 이벤트를 받지 못하던 현상 수정
- 책 요약 화면 (SummaryView)에서 도서 정보에 대해 발생하던 레이아웃 이슈 수정


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
https://github.com/user-attachments/assets/ad6f462e-6cef-448e-aa2b-a850dcb42253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 검색에 내 서재 도서 결과가 함께 표시되며, 구분된 스타일과 기록 수 배지를 지원합니다.
  - 내 서재 결과 항목 탭 시 도서 상세 화면으로 이동할 수 있습니다.
- 개선
  - 저자 정보가 없을 때 “저자 정보 없음” 플레이스홀더가 표시됩니다.
  - 저자/출판사 라벨 가독성이 향상되어 잘림이 줄었습니다.
  - 검색 화면 재진입 시 기존 결과가 유지됩니다.
  - 빠른 연속 탭 시 상세 화면 중복 이동을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->