### PR TITLE
feat: 감상평 가이드, 독서 기록 완료 시의 이슈 해결

### DIFF
--- a/src/Projects/BKDesign/Sources/Components/Dialog/BKDialog.swift
+++ b/src/Projects/BKDesign/Sources/Components/Dialog/BKDialog.swift
@@ -59,6 +59,8 @@ public final class BKDialog: UIView {
     private let titleText: String
     private let subtitleText: String?
     
+    let leftButtonAction: () -> Void
+    
     public init(
         title: String,
         subtitle: String? = nil,
@@ -69,6 +71,7 @@ public final class BKDialog: UIView {
         self.subtitleText = subtitle
         self.buttonGroup = Self.makeButtonGroup(config: config)
         self.suppliedContentStyle = suppliedContentStyle
+        self.leftButtonAction = config.leftButtonAction
         super.init(frame: .zero)
         
         setup()

--- a/src/Projects/BKDesign/Sources/Components/Dialog/BKDialogViewController.swift
+++ b/src/Projects/BKDesign/Sources/Components/Dialog/BKDialogViewController.swift
@@ -38,7 +38,7 @@ private extension BKDialogViewController {
     
     func configure() {
         dimView.tapHandler = { [weak self] in
-            self?.dismiss(animated: true)
+            self?.dialog.leftButtonAction()
         }
     }
     

--- a/src/Projects/BKDesign/Sources/Components/TextField/BKTextView.swift
+++ b/src/Projects/BKDesign/Sources/Components/TextField/BKTextView.swift
@@ -111,7 +111,7 @@ public final class BKTextView: UIView {
     public func startEditing(
         _ willMoveCaret: Bool = true
     ) {
-        guard window == textView.window else { return }
+        guard textView.window != nil else { return }
         
         if !textView.isFirstResponder {
             DispatchQueue.main.async {

--- a/src/Projects/BKDesign/Sources/Components/TextField/BKTextView.swift
+++ b/src/Projects/BKDesign/Sources/Components/TextField/BKTextView.swift
@@ -99,13 +99,29 @@ public final class BKTextView: UIView {
         textViewDidChange(textView)
     }
     
-    public func startEditing() {
-        guard window != nil, superview != nil else { return }
-
-        if textView.window != nil, !textView.isFirstResponder {
+    public func appendText(_ text: String) {
+        if self.textView.text.isEmpty {
+            self.textView.text = text
+        } else {
+            self.textView.text += "\n\(text)"
+        }
+        textViewDidChange(textView)
+    }
+    
+    public func startEditing(
+        _ willMoveCaret: Bool = true
+    ) {
+        guard window == textView.window else { return }
+        
+        if !textView.isFirstResponder {
             DispatchQueue.main.async {
-                self.textView.selectedRange = NSRange(location: 0, length: 0)
                 self.textView.becomeFirstResponder()
+            }
+        }
+        
+        if willMoveCaret {
+            DispatchQueue.main.async {
+                self.textView.moveCaretToStartOfLastLine()
             }
         }
     }

--- a/src/Projects/BKDesign/Sources/Extensions/UITextView+.swift
+++ b/src/Projects/BKDesign/Sources/Extensions/UITextView+.swift
@@ -1,0 +1,12 @@
+// Copyright © 2025 Booket. All rights reserved
+
+import UIKit
+
+extension UITextView {
+    func moveCaretToStartOfLastLine() {
+        let dir = UITextStorageDirection.backward.rawValue
+        if let lineRange = tokenizer.rangeEnclosingPosition(endOfDocument, with: .line, inDirection: UITextDirection(rawValue: dir)) {
+            selectedTextRange = textRange(from: lineRange.start, to: lineRange.start)
+        }
+    }
+}

--- a/src/Projects/BKPresentation/Sources/MainFlow/Note/View/NoteViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Note/View/NoteViewController.swift
@@ -78,8 +78,9 @@ final class NoteViewController: BaseViewController<NoteView> {
     override func bindState() {
         viewModel.statePublisher
             .receive(on: DispatchQueue.main)
-            .removeDuplicates()
             .map { $0.selectedGuideText }
+            .removeDuplicates()
+            .filter { !$0.isEmpty }
             .sink { [weak self] selectedText in
                 self?.contentView.setAppreciationText(selectedText)
             }
@@ -89,9 +90,8 @@ final class NoteViewController: BaseViewController<NoteView> {
             .receive(on: DispatchQueue.main)
             .map { $0.shouldStartEditing }
             .filter { $0 }
-            .removeDuplicates()
             .sink { [weak self] _ in
-                self?.contentView.startEditingIfNeeded() 
+                self?.contentView.startEditingIfNeeded()
             }
             .store(in: &cancellable)
         
@@ -107,8 +107,8 @@ final class NoteViewController: BaseViewController<NoteView> {
         
         viewModel.statePublisher
             .map(\.error)
-            .removeDuplicates()
             .compactMap { $0 }
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 self?.coordinator?.handleError(error)
@@ -176,7 +176,7 @@ private extension NoteViewController {
                 leftButtonTitle: "닫기",
                 leftButtonAction: { [weak self] in
                     self?.dismiss(animated: true)
-                    self?.navigationController?.popViewController(animated: true)
+                    self?.coordinator?.popAndFinish()
                 },
                 rightButtonTitle: "기록 보러가기",
                 rightButtonAction: { [weak self] in

--- a/src/Projects/BKPresentation/Sources/MainFlow/Note/View/SentenceAppreciationView.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Note/View/SentenceAppreciationView.swift
@@ -107,7 +107,7 @@ final class SentenceAppreciationView: BaseView {
     }
     
     func setText(_ content: String) {
-        appreciationTextView.setText(content)
+        appreciationTextView.appendText(content)
     }
     
     func startEditingIfNeeded() {

--- a/src/Projects/BKPresentation/Sources/MainFlow/Note/ViewModel/NoteViewModel.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Note/ViewModel/NoteViewModel.swift
@@ -116,4 +116,3 @@ final class NoteViewModel: BaseViewModel {
             .store(in: &cancellables)
     }
 }
-


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #198 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [x] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- BKDialog에서 취소가 아니라 dim을 통해 dismiss하는 경우, 무한정으로 독서 기록을 할 수 있던 버그 수정
- 감상평 가이드 사용 시 커서 위치가 제대로 첫 글자로 가도록 수정
- 감상평 가이드 사용 시 문장을 덮어쓰는 것이 아니라, 다음 줄에 가이드가 추가되도록 변경


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
https://github.com/user-attachments/assets/dfb98ecd-9298-48de-aa7b-3d817c0709c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - Vision 기반 OCR 처리 및 스캐너 개선(ROI, 가이드·하이라이트, 프레임 캡처 처리).
  - NLP 후처리(문장 재구성·영어 교정) 도입으로 인식 결과 품질 향상.
  - 텍스트 입력뷰에 내용 추가(append) 및 커서 이동 유틸리티 추가.

- 개선
  - 다이얼로그 바깥 탭이 왼쪽 버튼 동작을 실행하도록 행위 일관성 강화.
  - 등록/취소 흐름을 코디네이터 기반 네비게이션으로 통일.
  - 문장 감상 화면에서 텍스트가 누적되어 추가되도록 변경.

- 기타
  - 경미한 포맷 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->