### PR TITLE
feat: 로딩 인디케이터에 딜레이 적용

### DIFF
--- a/src/Projects/BKDesign/Sources/Components/BKLoading/BKLoadingIndicator.swift
+++ b/src/Projects/BKDesign/Sources/Components/BKLoading/BKLoadingIndicator.swift
@@ -16,14 +16,15 @@ public final class LoadingIndicator {
             guard delayedWorkItem == nil else { return }
 
             let workItem = DispatchWorkItem {
-                guard let window = getKeyWindow(), window.viewWithTag(tag) == nil else { return }
-
+                defer { delayedWorkItem = nil }
+                guard Self.delayedWorkItem?.isCancelled != true else { return }
+                guard let window = getKeyWindow() else { return }
+                guard window.viewWithTag(tag) == nil else { return }
+                
                 let loadingIndicatorView = createLoadingView(frame: window.bounds)
                 loadingIndicatorView.tag = tag
-
                 window.addSubview(loadingIndicatorView)
                 loadingIndicatorView.startAnimating()
-                delayedWorkItem = nil
             }
 
             delayedWorkItem = workItem
@@ -39,9 +40,9 @@ public final class LoadingIndicator {
                 
             guard let window = getKeyWindow() else { return }
             
-            window.subviews.filter({ $0.tag == tag }).forEach {
-                $0.removeFromSuperview()
-            }
+            window.subviews
+                .filter{ $0.tag == tag }
+                .forEach { $0.removeFromSuperview() }
         }
     }
     

--- a/src/Projects/BKDesign/Sources/Components/BKLoading/BKLoadingIndicator.swift
+++ b/src/Projects/BKDesign/Sources/Components/BKLoading/BKLoadingIndicator.swift
@@ -1,32 +1,42 @@
 // Copyright © 2025 Booket. All rights reserved
 
-import UIKit
 import SnapKit
+import UIKit
 
 public final class LoadingIndicator {
     
     private static let tag = 999999
+    private static var delayedWorkItem: DispatchWorkItem?
     
     /// 로딩 인디케이터 보여주기
-    public static func show() {
+    public static func show(
+        delay: TimeInterval = 0.5
+    ) {
         DispatchQueue.main.async {
-            guard let window = getKeyWindow() else { return }
-            
-            if window.viewWithTag(tag) != nil {
-                return
+            guard delayedWorkItem == nil else { return }
+
+            let workItem = DispatchWorkItem {
+                guard let window = getKeyWindow(), window.viewWithTag(tag) == nil else { return }
+
+                let loadingIndicatorView = createLoadingView(frame: window.bounds)
+                loadingIndicatorView.tag = tag
+
+                window.addSubview(loadingIndicatorView)
+                loadingIndicatorView.startAnimating()
+                delayedWorkItem = nil
             }
-            
-            let loadingIndicatorView = createLoadingView(frame: window.bounds)
-            loadingIndicatorView.tag = tag
-            
-            window.addSubview(loadingIndicatorView)
-            loadingIndicatorView.startAnimating()
+
+            delayedWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
         }
     }
     
     /// 로딩 인디케이터 숨기기
     public static func hide() {
         DispatchQueue.main.async {
+            delayedWorkItem?.cancel()
+            delayedWorkItem = nil
+                
             guard let window = getKeyWindow() else { return }
             
             window.subviews.filter({ $0.tag == tag }).forEach {

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteCompletion/View/NoteCompletionViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteCompletion/View/NoteCompletionViewController.swift
@@ -60,7 +60,6 @@ final class NoteCompletionViewController: BaseViewController<NoteCompletionView>
             }
             .store(in: &cancellable)
         
-        
         viewModel.statePublisher
             .map { $0.isLoading }
             .removeDuplicates()
@@ -77,18 +76,8 @@ final class NoteCompletionViewController: BaseViewController<NoteCompletionView>
         viewModel.statePublisher
             .receive(on: DispatchQueue.main)
             .compactMap { $0.error }
-            .sink { [weak self] error in
-                // 에러 알림 표시 -> BKStyle로 교체 필요
-                let alert = UIAlertController(
-                    title: "오류",
-                    message: "기록을 불러올 수 없습니다.",
-                    preferredStyle: .alert
-                )
-                alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
-                    self?.viewModel.send(.errorHandled)
-                    self?.dismiss(animated: true)
-                })
-                self?.present(alert, animated: true)
+            .sink { [weak self] _ in
+                self?.presentErrorDialog()
             }
             .store(in: &cancellable)
         
@@ -173,6 +162,22 @@ final class NoteCompletionViewController: BaseViewController<NoteCompletionView>
         )
         let dialogViewController = BKDialogViewController(dialog: dialog)
         present(dialogViewController, animated: true)
+    }
+    
+    func presentErrorDialog() {
+        let dialog = BKDialog(
+            title: "오류",
+            config: .init(
+                leftButtonTitle: "기록을 불러올 수 없습니다.",
+                leftButtonAction: { [weak self] in
+                    self?.dismiss(animated: true) { [weak self] in
+                        self?.viewModel.send(.errorHandled)
+                    }
+                }
+            )
+        )
+        let dialogViewController = BKDialogViewController(dialog: dialog)
+        self.present(dialogViewController, animated: true)
     }
     
     @objc private func customBackButtonTapped() {


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #208 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [x] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 로딩 화면의 타이밍 조정 (0ms -> 500ms)


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
https://github.com/user-attachments/assets/5c197f9a-6450-4aed-b7b2-97277f751cc7

~~서버 로딩이 너무 빨라서 인디케이터가 보기 쉽지 않네요.~~
로딩 시간이 500ms를 넘어가야만 로딩 인디케이터가 나옵니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로딩 인디케이터가 기본 0.5초 지연 후 표시되어 매우 빠른 작업에서 깜빡임이 감소하고, 지연 시간 내 완료 시 자동 취소되어 흐름이 매끄러워집니다.
  - 오류 처리 UI가 시스템 알림에서 통일된 대화상자(BKDialog)로 변경되어 사용자에게 일관된 오류 메시지와 회복 동작을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->