### PR TITLE
feat: 검색 > 도서 등록 상태별 Sheet 분기 처리

### DIFF
--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/VO/BookRegistrationStatus.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/VO/BookRegistrationStatus.swift
@@ -28,4 +28,35 @@ enum BookRegistrationStatus: String {
             return .after
         }
     }
+    
+    func getSubTitle() -> String {
+        switch self {
+        case .before:
+            return "책을 읽으면서 독서 기록을 남길 수 있어요"
+        case .inProgress:
+            return "독서 기록을 바로 시작할까요?"
+        case .after:
+            return "기억에 남은 문장이나 감상을 기록해보세요"
+        }
+    }
+    
+    func getCancelButtonTitle() -> String {
+        switch self {
+        case .before:
+            return "확인"
+        case .inProgress, .after:
+            return "나중에 하기"
+        }
+    }
+    
+    func getNextButtonTitle() -> String {
+        switch self {
+        case .inProgress:
+            return "기록 시작하기"
+        case .after:
+            return "기록 남기기"
+        default:
+            return ""
+        }
+    }
 }

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/View/SearchViewController.swift
@@ -168,11 +168,19 @@ final class SearchViewController: BaseViewController<SearchView>, ScreenLoggable
             .store(in: &cancellable)
         
         viewModel.statePublisher
-            .compactMap { $0.isUpserted }
-            .removeDuplicates()
+            .compactMap { state -> (isbn: String, status: BookRegistrationStatus)? in
+                guard let isbn = state.isUpserted,
+                      let status = state.selectedStatus else {
+                    return nil
+                }
+                return (isbn, status)
+            }
+            .removeDuplicates { previous, current in
+                return previous.isbn == current.isbn && previous.status == current.status
+            }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isbn in
-                self?.presentNoteSuggestion(with: isbn)
+            .sink { [weak self] (isbn, status) in
+                self?.presentNoteSuggestion(with: isbn, status: status)
                 self?.viewModel.send(.noteSuggestionShown)
             }
             .store(in: &cancellable)
@@ -273,32 +281,49 @@ private extension SearchViewController {
         viewModel.send(.upsertBook(isbn: isbn, status: status))
     }
     
-    func presentNoteSuggestion(with isbn: String) {
+    func presentNoteSuggestion(with isbn: String, status: BookRegistrationStatus) {
         let graphic = BKImage.Graphics.coinCheck
         let graphicView = UIImageView(image: graphic)
         graphicView.snp.makeConstraints {
             $0.size.equalTo(CGSize(width: 120, height: 120))
         }
+        
+        let sheetTitle = "도서가 등록되었어요!"
+        let cancelAction : (() -> Void)? = { [weak self] in
+            self?.dismiss(animated: true)
+            self?.hideLoading()
+        }
+        
+        let nextAction : (() -> Void)? = { [weak self] in
+            self?.dismiss(animated: true)
+            self?.viewModel.send(.loadNoteFlow)
+            self?.hideLoading()
+            
+        }
         logScreenView(name: GATracking.SearchAndRegister.complete)
         
+        var buttonGroup: BKButtonGroup?
+        
+        if status == .before {
+            buttonGroup = .singleFullButton(
+                title: status.getCancelButtonTitle(),
+                action: cancelAction
+            )
+        } else {
+            buttonGroup = .twoButtonGroup(
+                leftTitle: status.getCancelButtonTitle(),
+                rightTitle: status.getNextButtonTitle(),
+                leftAction: cancelAction,
+                rightAction: nextAction
+            )
+        }
+        
         let sheet = BKBottomSheetViewController(
-            title: "도서가 등록되었어요!",
-            subtitle: "독서 기록을 바로 시작할까요?",
+            title: sheetTitle,
+            subtitle: status.getSubTitle(),
             style: .centered,
             suppliedContentStyle: .upper(graphicView),
-            buttonConfiguration: .twoButtonGroup(
-                leftTitle: "나중에 하기",
-                rightTitle: "기록 시작하기",
-                leftAction: { [weak self] in
-                    self?.dismiss(animated: true)
-                    self?.hideLoading()
-                },
-                rightAction: { [weak self] in
-                    self?.dismiss(animated: true)
-                    self?.viewModel.send(.loadNoteFlow)
-                    self?.hideLoading()
-                }
-            )
+            buttonConfiguration: buttonGroup
         )
         
         sheet.show(from: self, animated: true)

--- a/src/Projects/BKPresentation/Sources/MainFlow/Search/ViewModel/SearchViewModel.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/Search/ViewModel/SearchViewModel.swift
@@ -92,6 +92,7 @@ final class SearchViewModel: BaseViewModel {
         var searchBarPlaceholder: String
         var searchViewTitle: String
         var isUpserted: String? = nil
+        var selectedStatus: BookRegistrationStatus? = nil
         var viewType: SearchViewType? = nil
     }
     
@@ -274,6 +275,7 @@ final class SearchViewModel: BaseViewModel {
                 newState.error = .unauthorized
             } else {
                 newState.isLoading = true
+                newState.selectedStatus = status
                 effects.append(.upsert(isbn: isbn, status: status))
             }
             
@@ -284,6 +286,7 @@ final class SearchViewModel: BaseViewModel {
             
         case .noteSuggestionShown:
             newState.isUpserted = nil
+            newState.selectedStatus = nil
             
         case .errorOccured(let error):
             newState.isLoading = false


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #227 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [x] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- BookRegistrationStatus 내부에 Helper 함수 추가
- searchVM에 BookRegistrationStatus 관련 state 추가
- searchVC에서 present 함수 내부 로직 수정


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
https://github.com/user-attachments/assets/0e25dada-697e-4840-b4f3-452ae9016d26



## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 도서 등록 상태에 따라 노트 제안 화면의 제목·부제·버튼 구성이 동적으로 표시되도록 추가
  * 등록 상태별(등록 전/진행 중/등록 후) 맞춤 버튼 레이블 및 동작 제공

* **개선 사항**
  * 선택된 등록 상태를 추적해 중복 표시를 방지하도록 상태 관리 강화
  * 노트 제안 흐름에서 상태에 따른 네비게이션 및 정리 동작 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->