### PR TITLE
fix: 기록 수정 화면에서의 로직 개선

### DIFF
--- a/src/Projects/BKDomain/Sources/Entity/Emotion.swift
+++ b/src/Projects/BKDomain/Sources/Entity/Emotion.swift
@@ -1,6 +1,6 @@
 // Copyright © 2025 Booket. All rights reserved
 
-public enum Emotion: String, CaseIterable, Decodable, Equatable {
+public enum Emotion: String, CaseIterable, Decodable {
     case warmth = "따뜻함"
     case joy = "즐거움"
     case sad = "슬픔"

--- a/src/Projects/BKDomain/Sources/Entity/Emotion.swift
+++ b/src/Projects/BKDomain/Sources/Entity/Emotion.swift
@@ -1,6 +1,6 @@
 // Copyright © 2025 Booket. All rights reserved
 
-public enum Emotion: String, CaseIterable, Decodable {
+public enum Emotion: String, CaseIterable, Decodable, Equatable {
     case warmth = "따뜻함"
     case joy = "즐거움"
     case sad = "슬픔"

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/EmotionEditView.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/EmotionEditView.swift
@@ -6,23 +6,21 @@ import Combine
 import UIKit
 import SnapKit
 
+enum EmotionEditViewEvent {
+    case editButtonTapped
+    case emotionDidChange(Emotion?)
+}
+
 final class EmotionEditView: BaseView {
     private let scrollView = UIScrollView()
     private let contentView = UIView()
     private let emotionRegistrationView = EmotionRegistrationView()
     private let editButton = BKButton(style: .primary, size: .large)
     
-    private let editButtonTappedSubject = PassthroughSubject<Void, Never>()
-    var editButtonTappedPublisher: AnyPublisher<Void, Never> {
-        editButtonTappedSubject.eraseToAnyPublisher()
-    }
+    let eventPublisher = PassthroughSubject<EmotionEditViewEvent, Never>()
+    private var cancellables = Set<AnyCancellable>()
     
-    private let getCurrentEmotionSubject = PassthroughSubject<Void, Never>()
-    var getCurrentEmotionPublisher: AnyPublisher<Void, Never> {
-        getCurrentEmotionSubject.eraseToAnyPublisher()
-    }
-    
-    var selectedEmotion: Emotion? {
+    private var currentSelectedEmotion: Emotion? {
         guard let form = emotionRegistrationView.registrationForm(),
               case .emotion(let emotionForm) = form else { return nil }
         return emotionForm.emotion
@@ -37,6 +35,15 @@ final class EmotionEditView: BaseView {
     override func configure() {
         editButton.title = "수정하기"
         editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+        
+        emotionRegistrationView.inputChangedPublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+    
+                let newEmotion = self.currentSelectedEmotion
+                self.eventPublisher.send(.emotionDidChange(newEmotion))
+            }
+            .store(in: &cancellables)
     }
     
     override func setupLayout() {
@@ -69,12 +76,12 @@ final class EmotionEditView: BaseView {
         emotionRegistrationView.setSelectedEmotion(emotion)
     }
     
-    func getCurrentSelectedEmotion() {
-        getCurrentEmotionSubject.send(())
+    @objc private func editButtonTapped() {
+        eventPublisher.send(.editButtonTapped)
     }
     
-    @objc private func editButtonTapped() {
-        editButtonTappedSubject.send(())
+    func setEditButtonEnabled(_ isEnabled: Bool) {
+        editButton.isDisabled = !isEnabled
     }
 }
 

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/EmotionEditViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/EmotionEditViewController.swift
@@ -16,30 +16,41 @@ final class EmotionEditViewController: BaseViewController<EmotionEditView> {
     weak var coordinator: NoteEditCoordinator?
     private var cancellables = Set<AnyCancellable>()
     
-    private let currentEmotion: Emotion?
+    private let initialEmotion: Emotion?
+    @Published private var selectedEmotion: Emotion?
     private let completion: (Emotion) -> Void
     
     init(currentEmotion: Emotion?, completion: @escaping (Emotion) -> Void) {
-        self.currentEmotion = currentEmotion
+        self.initialEmotion = currentEmotion
         self.completion = completion
+        self._selectedEmotion = .init(initialValue: currentEmotion)
         super.init()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // 현재 선택된 감정이 있으면 초기 설정
-        if let emotion = currentEmotion {
+        if let emotion = initialEmotion {
             contentView.setSelectedEmotion(emotion)
         }
+        contentView.setEditButtonEnabled(false)
     }
     
     override func bindAction() {
-        contentView.editButtonTappedPublisher
-            .compactMap { [weak self] in self?.contentView.selectedEmotion }
-            .sink { [weak self] selectedEmotion in
-                self?.completion(selectedEmotion)
-                self?.navigationController?.popViewController(animated: true)
+        contentView.eventPublisher
+            .sink { [weak self] event in
+                guard let self = self else { return }
+                switch event {
+                case .emotionDidChange(let newEmotion):
+                    self.selectedEmotion = newEmotion
+                    let isDiff = (newEmotion != self.initialEmotion)
+                    self.contentView.setEditButtonEnabled(isDiff)
+                case .editButtonTapped:
+                    if let emotion = self.selectedEmotion {
+                        self.completion(emotion)
+                        self.navigationController?.popViewController(animated: true)
+                    }
+                }
             }
             .store(in: &cancellables)
     }

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/NoteEditView.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/NoteEditView.swift
@@ -9,6 +9,9 @@ import UIKit
 enum NoteEditViewEvent {
     case emotionStatusTapped
     case saveButtonTapped
+    case pageDidChange(String)
+    case sentenceDidChange(String)
+    case appreciationDidChange(String)
 }
 
 final class NoteEditView: BaseView {
@@ -110,6 +113,26 @@ final class NoteEditView: BaseView {
         emotionStatusView.isUserInteractionEnabled = true
         
         // BKTextFieldView와 BKTextView는 자체적으로 탭을 처리하므로 별도 제스처 불필요
+        pageField.textDidChangePublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.eventPublisher.send(.pageDidChange(self.pageField.text))
+            }
+            .store(in: &cancellables)
+        
+        sentenceTextView.textDidChangePublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.eventPublisher.send(.sentenceDidChange(self.sentenceTextView.text))
+            }
+            .store(in: &cancellables)
+        
+        appreciationTextView.textDidChangePublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.eventPublisher.send(.appreciationDidChange(self.appreciationTextView.text))
+            }
+            .store(in: &cancellables)
         
         // 전체 뷰에 탭 제스처 추가 (키보드 dismiss용)
         let dismissTapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
@@ -156,6 +179,7 @@ final class NoteEditView: BaseView {
             target: self,
             selector: #selector(pageFieldDidBeginEditing)
         )
+        
     }
     
     @objc private func sentenceTextViewDidBeginEditing(_ notification: Notification) {
@@ -268,6 +292,10 @@ final class NoteEditView: BaseView {
     
     func updateEmotionLabel(_ text: String) {
         emotionLabel.setText(text: text)
+    }
+    
+    public func setSaveButtonEnabled(_ isEnabled: Bool) {
+        saveButton.isDisabled = !isEnabled
     }
     
     func getCurrentFormData() -> (page: Int?, sentence: String, appreciation: String) {

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/NoteEditViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/NoteEditViewController.swift
@@ -42,6 +42,7 @@ final class NoteEditViewController: BaseViewController<NoteEditView>, ScreenLogg
         )
         navigationItem.leftBarButtonItem = backButton
         
+        contentView.setSaveButtonEnabled(false)
         viewModel.send(.onAppear)
     }
     
@@ -121,16 +122,31 @@ final class NoteEditViewController: BaseViewController<NoteEditView>, ScreenLogg
             }
             .store(in: &cancellables)
         
+        viewModel.statePublisher
+            .map { $0.isDiff }
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isDiff in
+                self?.contentView.setSaveButtonEnabled(isDiff)
+            }
+            .store(in: &cancellables)
     }
     
     override func bindAction() {
         contentView.eventPublisher
             .sink { [weak self] event in
+                guard let self = self else { return }
                 switch event {
                 case .emotionStatusTapped:
-                    self?.presentEmotionEdit()
+                    self.presentEmotionEdit()
                 case .saveButtonTapped:
-                    self?.handleSaveButtonTapped()
+                    self.handleSaveButtonTapped()
+                case .pageDidChange(let text):
+                    self.viewModel.send(.pageDidChange(text))
+                case .sentenceDidChange(let text):
+                    self.viewModel.send(.sentenceDidChange(text))
+                case .appreciationDidChange(let text):
+                    self.viewModel.send(.appreciationDidChange(text))
                 }
             }
             .store(in: &cancellables)
@@ -153,8 +169,7 @@ private extension NoteEditViewController {
     }
     
     func handleSaveButtonTapped() {
-        let formData = contentView.getCurrentFormData()
-        viewModel.send(.saveButtonTapped(formData: formData))
+        viewModel.send(.saveButtonTapped)
     }
     
     func presentBookMoreMenu() {

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/NoteEditViewController.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/View/NoteEditViewController.swift
@@ -42,7 +42,6 @@ final class NoteEditViewController: BaseViewController<NoteEditView>, ScreenLogg
         )
         navigationItem.leftBarButtonItem = backButton
         
-        contentView.setSaveButtonEnabled(false)
         viewModel.send(.onAppear)
     }
     

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/ViewModel/NoteEditViewModel.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/ViewModel/NoteEditViewModel.swift
@@ -79,6 +79,9 @@ final class NoteEditViewModel: BaseViewModel {
         
         switch action {
         case .onAppear:
+            guard state.initialRecordInfo == nil else {
+                break
+            }
             newState.isLoading = true
             newState.isDiff = false
             effects.append(.fetchRecordDetail(recordId))

--- a/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/ViewModel/NoteEditViewModel.swift
+++ b/src/Projects/BKPresentation/Sources/MainFlow/NoteEdit/ViewModel/NoteEditViewModel.swift
@@ -14,6 +14,12 @@ final class NoteEditViewModel: BaseViewModel {
         var shouldPresentEmotionEdit: (emotion: Emotion?, timestamp: Date)?
         var saveCompleted: Bool = false
         var deleteCompleted: Bool = false
+        
+        var currentFormData: (page: String, sentence: String, appreciation: String) = ("", "", "")
+        
+        var initialRecordInfo: RecordInfo?
+        var initialSelectedEmotion: Emotion?
+        var isDiff: Bool = false // 변경 내용이 있는지 추적
     }
     
     enum Action {
@@ -23,10 +29,15 @@ final class NoteEditViewModel: BaseViewModel {
         case errorHandled
         case presentEmotionEdit
         case emotionSelected(Emotion)
-        case saveButtonTapped(formData: (page: Int?, sentence: String, appreciation: String?))
+        
+        case saveButtonTapped
         case patchRecordSuccessed(RecordInfo)
         case deleteButtonTapped
         case deleteRecordSuccessed
+        
+        case pageDidChange(String)
+        case sentenceDidChange(String)
+        case appreciationDidChange(String)
     }
     
     enum SideEffect {
@@ -69,15 +80,27 @@ final class NoteEditViewModel: BaseViewModel {
         switch action {
         case .onAppear:
             newState.isLoading = true
+            newState.isDiff = false
             effects.append(.fetchRecordDetail(recordId))
             
         case .fetchRecordDetailSuccessed(let recordInfo):
             newState.recordInfo = recordInfo
+            newState.initialRecordInfo = recordInfo
+            
+            newState.currentFormData = (
+                page: "\(recordInfo.pageNumber)",
+                sentence: recordInfo.quote,
+                appreciation: recordInfo.review ?? ""
+            )
+            
             // 사용자가 이미 감정을 선택했다면 덮어쓰지 않음
             if newState.selectedEmotion == nil {
-                newState.selectedEmotion = recordInfo.emotionTags.first
+                let initialEmotion = recordInfo.emotionTags.first
+                newState.selectedEmotion = initialEmotion
+                newState.initialSelectedEmotion = initialEmotion
             }
             newState.isLoading = false
+            newState.isDiff = false
             
         case .errorOccured(let error):
             newState.error = error
@@ -91,19 +114,25 @@ final class NoteEditViewModel: BaseViewModel {
             
         case .emotionSelected(let emotion):
             newState.selectedEmotion = emotion
+            newState.isDiff = checkForDiff(state: newState)
             
-        case .saveButtonTapped(let formData):
+        case .saveButtonTapped:
             guard let selectedEmotion = state.selectedEmotion,
-                  let page = formData.page,
-                  !formData.sentence.isEmpty else {
+                  let page = Int(state.currentFormData.page),
+                  !state.currentFormData.sentence.isEmpty else {
                 break
             }
             
+            // 감상평이 비어있으면 nil, 아니면 텍스트 전달
+            let appreciation = state.currentFormData.appreciation.isEmpty
+            ? nil
+            : state.currentFormData.appreciation
+            
             let noteForm = NoteForm(
                 page: page,
-                sentence: formData.sentence,
+                sentence: state.currentFormData.sentence,
                 emotion: selectedEmotion,
-                appreciation: formData.appreciation
+                appreciation: appreciation
             )
             
             newState.isLoading = true
@@ -111,8 +140,15 @@ final class NoteEditViewModel: BaseViewModel {
             
         case .patchRecordSuccessed(let recordInfo):
             newState.recordInfo = recordInfo
+            newState.initialRecordInfo = recordInfo
+            newState.currentFormData = (
+                page: "\(recordInfo.pageNumber)",
+                sentence: recordInfo.quote,
+                appreciation: recordInfo.review ?? ""
+            )
             newState.isLoading = false
             newState.saveCompleted = true
+            newState.isDiff = false
             
         case .deleteButtonTapped:
             newState.isLoading = true
@@ -121,6 +157,18 @@ final class NoteEditViewModel: BaseViewModel {
         case .deleteRecordSuccessed:
             newState.isLoading = false
             newState.deleteCompleted = true
+            
+        case .pageDidChange(let text):
+            newState.currentFormData.page = text
+            newState.isDiff = checkForDiff(state: newState)
+            
+        case .sentenceDidChange(let text):
+            newState.currentFormData.sentence = text
+            newState.isDiff = checkForDiff(state: newState)
+            
+        case .appreciationDidChange(let text):
+            newState.currentFormData.appreciation = text
+            newState.isDiff = checkForDiff(state: newState)
         }
         
         return (newState, effects)
@@ -158,6 +206,20 @@ final class NoteEditViewModel: BaseViewModel {
             }
             .sink(receiveValue: send(_:))
             .store(in: &cancellables)
+    }
+    
+    private func checkForDiff(state: State) -> Bool {
+        guard let initialInfo = state.initialRecordInfo else {
+            return false
+        }
+        
+        let pageDiff = state.currentFormData.page != "\(initialInfo.pageNumber)"
+        let sentenceDiff = state.currentFormData.sentence != initialInfo.quote
+        let appreciationDiff = state.currentFormData.appreciation != (initialInfo.review ?? "")
+        
+        let emotionDiff = state.selectedEmotion != state.initialSelectedEmotion
+        
+        return pageDiff || sentenceDiff || appreciationDiff || emotionDiff
     }
 }
 


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #251 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [x] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [x] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- NoteEditView/VC/VM 로직 수정
- EmotionEditView/VC 로직 수정


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
https://github.com/user-attachments/assets/43d00e74-cf02-4aee-a4bf-951eb0e924b9


## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- EmotionEditView에 VM가 없지만, 또 VM으로 처리할만큼 로직이 많은 것도 아닌 것 같아 일단 completion 으로 data 전달하는 방식을 유지하되, 새로 select된 emotion 추적을 쉽게 하기 위해 `@Published`를 사용하였습니다. 그리고 ViewEvent 구조로 개편하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새 기능**
  * 감정 편집 및 노트 저장 버튼의 상태 관리 개선
  * 폼 필드 변경 사항 실시간 추적 기능 추가

* **버그 수정**
  * 감정 선택 및 폼 저장 흐름 안정성 개선

* **리팩터**
  * 이벤트 기반 아키텍처로 내부 통신 패턴 통합
  * 폼 상태 관리 및 변경 감지 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->