### PR TITLE
feat: BKTextButton component 추가

### DIFF
--- a/src/Projects/BKDesign/PreviewApp/Sources/View/BKButtonTestViewController.swift
+++ b/src/Projects/BKDesign/PreviewApp/Sources/View/BKButtonTestViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Booket. All rights reserved
+// Copyright © 2026 Booket. All rights reserved
 
 import BKDesign
 import SnapKit
@@ -52,6 +52,9 @@ public final class BKButtonTestViewController: UIViewController {
         setupButtons(for: .medium)
         setupButtons(for: .small)
         setupButtons(for: .rounded)
+        
+        addSectionSeparator()
+        setupTextButtons()
     }
     
     private func setupButtons(for size: BKButtonSize) {
@@ -64,6 +67,39 @@ public final class BKButtonTestViewController: UIViewController {
         addIconButton("Apple 로그인", style: .primary, size: size, left: BKImage.Icon.apple)
         addIconButton("카카오 로그인", style: .primary, size: size, right: BKImage.Icon.kakao)
         addIconButton("양쪽 아이콘", style: .primary, size: size, left: BKImage.Icon.apple, right: BKImage.Icon.kakao)
+    }
+    
+    // MARK: - Text Button Tests
+    
+    private func setupTextButtons() {
+        addSectionHeader("Text Buttons")
+        
+        addTextButton("텍스트 버튼1", size: .small)
+        addTextButton("텍스트 버튼2", size: .medium)
+        addTextButton("텍스트 버튼3", size: .large)
+        addTextButton("아주 긴 내용의 텍스트 버튼을 만들어봅시다", size: .large)
+        addDisabledTextButton("비활성화 텍스트", size: .small)
+    }
+    
+    private func addTextButton(_ title: String, size: BKButtonSize) {
+        let button = BKTextButton(title: "[\(size.label)] \(title)", size: size)
+        containerView.addArrangedSubview(wrapForLeftAlign(button))
+    }
+    
+    private func addDisabledTextButton(_ title: String, size: BKButtonSize) {
+        let button = BKTextButton(title: "[\(size.label)] \(title)", size: size)
+        button.isDisabled = true
+        containerView.addArrangedSubview(wrapForLeftAlign(button))
+    }
+    
+    /// 텍스트 버튼은 intrinsic size를 사용하므로 왼쪽 정렬 래퍼 필요
+    private func wrapForLeftAlign(_ view: UIView) -> UIView {
+        let wrapper = UIView()
+        wrapper.addSubview(view)
+        view.snp.makeConstraints {
+            $0.leading.verticalEdges.equalToSuperview()
+        }
+        return wrapper
     }
     
     // MARK: - Button Builders
@@ -95,41 +131,26 @@ public final class BKButtonTestViewController: UIViewController {
         containerView.addArrangedSubview(button)
     }
     
-    private func setupIndependentButtons() {
-        let sampleView = UIView()
-        scrollView.addSubview(sampleView)
-        sampleView.snp.makeConstraints {
-            $0.top.equalTo(containerView.snp.bottom).offset(40)
-            $0.centerX.equalToSuperview()
-            $0.bottom.lessThanOrEqualToSuperview()
-        }
-
-        let buttons: [BKButton] = [
-            .primary(title: "[Free] Apple 로그인", size: .large),
-            .secondary(title: "[Free] Secondary", size: .large),
-            .tertiary(title: "[Free] Tertiary", size: .large),
-            .primary(title: "[Free] Apple 로그인", size: .medium),
-            .secondary(title: "[Free] Secondary", size: .small),
-            .tertiary(title: "[Free] Tertiary", size: .rounded)
-        ]
-
-        buttons[0].leftIcon = BKImage.Icon.apple
-        buttons[2].rightIcon = BKImage.Icon.kakao
-
-        var last: UIView?
-        for button in buttons {
-            sampleView.addSubview(button)
-            button.snp.makeConstraints {
-                $0.centerX.equalToSuperview()
-                $0.top.equalTo(last?.snp.bottom ?? sampleView.snp.top).offset(16)
-            }
-            last = button
-        }
+    // MARK: - Section Helpers
+    
+    private func addSectionHeader(_ title: String) {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 18, weight: .bold)
+        label.textColor = .darkGray
+        containerView.addArrangedSubview(label)
     }
-
+    
+    private func addSectionSeparator() {
+        let separator = UIView()
+        separator.backgroundColor = .systemGray4
+        separator.snp.makeConstraints { $0.height.equalTo(1) }
+        containerView.addArrangedSubview(separator)
+        containerView.setCustomSpacing(24, after: separator)
+    }
 }
 
-
+// MARK: - BKButtonSize Extension
 public extension BKButtonSize {
     var label: String {
         switch self {

--- a/src/Projects/BKDesign/Sources/Components/Button/BKTextButton.swift
+++ b/src/Projects/BKDesign/Sources/Components/Button/BKTextButton.swift
@@ -1,0 +1,172 @@
+// Copyright © 2025 Booket. All rights reserved
+
+import SnapKit
+import UIKit
+
+/// 밑줄이 있는 텍스트 버튼 컴포넌트입니다.
+///
+/// 링크 스타일의 텍스트 버튼으로, 배경 없이 텍스트와 밑줄만 표시됩니다.
+/// `BKButtonGroup`과 함께 사용할 수 있습니다.
+public final class BKTextButton: UIControl {
+    
+    // MARK: - Public Properties
+    
+    /// 버튼에 표시될 텍스트
+    public var title: String? {
+        didSet {
+            titleLabel.text = title
+            invalidateIntrinsicContentSize()
+        }
+    }
+    
+    /// 버튼의 비활성화 여부
+    public var isDisabled: Bool = false {
+        didSet {
+            isEnabled = !isDisabled
+            updateColors()
+        }
+    }
+    
+    /// 버튼 크기 (폰트 크기에 영향)
+    public var size: BKButtonSize = .small {
+        didSet {
+            titleLabel.font = size.font
+            invalidateIntrinsicContentSize()
+        }
+    }
+    
+    /// 텍스트 및 밑줄 색상 설정
+    public var foregroundColors: BKButtonColorSet = BKButtonColorSet(
+        normal: .bkContentColor(.brand),
+        pressed: .bkContentColor(.brand),
+        disabled: .bkContentColor(.disable)
+    ) {
+        didSet {
+            updateColors()
+        }
+    }
+    
+    // MARK: - Override Properties
+    
+    public override var isHighlighted: Bool {
+        didSet {
+            updateColors()
+            animatePressedState()
+        }
+    }
+    
+    public override var isEnabled: Bool {
+        didSet {
+            updateColors()
+        }
+    }
+    
+    // MARK: - Private Properties
+    
+    private let titleLabel = UILabel()
+    private let underlineView = UIView()
+    
+    private let animationDuration: TimeInterval = 0.15
+    
+    private var currentState: BKButtonState {
+        BKButtonState(isEnabled: isEnabled, isHighlighted: isHighlighted)
+    }
+    
+    // MARK: - Initialization
+    
+    public init(title: String? = nil, size: BKButtonSize = .small) {
+        super.init(frame: .zero)
+        self.title = title
+        self.size = size
+        setupViews()
+        updateColors()
+    }
+    
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+        updateColors()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupViews() {
+        setupTitleLabel()
+        setupUnderlineView()
+    }
+    
+    private func setupTitleLabel() {
+        addSubview(titleLabel)
+        
+        titleLabel.text = title
+        titleLabel.font = size.font
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 1
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    private func setupUnderlineView() {
+        addSubview(underlineView)
+        
+        underlineView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(1)
+            $0.leading.trailing.equalTo(titleLabel)
+            $0.height.equalTo(1)
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Update Methods
+    
+    private func updateColors() {
+        let color = foregroundColors.color(for: currentState)
+        titleLabel.textColor = color
+        underlineView.backgroundColor = color
+    }
+    
+    // MARK: - Animation
+    
+    private func animatePressedState() {
+        let targetAlpha: CGFloat = isHighlighted ? 0.6 : 1.0
+        UIView.animate(
+            withDuration: animationDuration,
+            delay: 0,
+            options: [.allowUserInteraction, .beginFromCurrentState],
+            animations: {
+                self.titleLabel.alpha = targetAlpha
+                self.underlineView.alpha = targetAlpha
+            }
+        )
+    }
+    
+    // MARK: - Intrinsic Content Size
+    
+    public override var intrinsicContentSize: CGSize {
+        let labelSize = titleLabel.intrinsicContentSize
+        // 라벨 높이 + 밑줄 오프셋(1) + 밑줄 높이(1)
+        return CGSize(
+            width: labelSize.width,
+            height: labelSize.height + 2
+        )
+    }
+}
+
+// MARK: - Factory Methods
+extension BKTextButton {
+    /// 텍스트 버튼 생성
+    public static func text(title: String, size: BKButtonSize = .small) -> BKTextButton {
+        BKTextButton(title: title, size: size)
+    }
+}
+
+/* 커스텀 색상세트 사용 시
+ let customButton = BKTextButton(title: "커스텀", size: .small)
+ customButton.foregroundColors = BKButtonColorSet(
+     normal: .systemBlue,
+     pressed: .systemBlue,
+     disabled: .systemGray
+ )
+ */


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #223 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [x] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [x] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- BKTextButton을 추가하였습니다. 기존 BKButton의 config 항목들을 최대한 활용하되, 기존 버튼 스타일과 다른 점이 많아(좌/우 아이콘 옵션 여부, 배경색 여부, 버튼 사이즈 측정 방식) 아예 별도의 BKTextButton 컴포넌트를 정의하였습니다.
- PreviewApp의 BKButtonTestViewController에 예시 텍스트 버튼 항목을 추가하였습니다.
- 텍스트 + 라인 스타일 상 여러 줄의 텍스트는 커버하지 않습니다.


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
<img width="400"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-03 at 15 32 47" src="https://github.com/user-attachments/assets/0866ebe5-3c76-447f-a020-d0d6232fecd9" />


## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- 로그인 화면 개편에서 사용하시면 됩니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 언더라인 스타일의 텍스트 버튼 컴포넌트 추가: 다양한 크기 및 비활성화 상태를 지원하는 새로운 텍스트 버튼 컴포넌트 출시
* 미리보기 앱에 텍스트 버튼 테스트 섹션 추가: 여러 버튼 크기 및 상태 변형을 테스트할 수 있는 전용 섹션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->